### PR TITLE
Fix search input clearing

### DIFF
--- a/_javascript/modules/components/search-display.js
+++ b/_javascript/modules/components/search-display.js
@@ -63,7 +63,7 @@ class ResultSwitch {
       content.forEach((el) => {
         el.classList.remove(UNLOADED);
       });
-      input.textContent = '';
+      input.value = '';
       this.resultVisible = false;
     }
   }


### PR DESCRIPTION
## Summary
- reset search input using `input.value = ''` instead of `textContent`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b35cd38c48330be49f4c59ff92780