### PR TITLE
Add projects collection and portfolio listing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -181,6 +181,9 @@ collections:
   code_days:
     sort_by: date
     output: false
+  projects:
+    sort_by: date
+    output: true
 
 defaults:
   - scope:
@@ -193,6 +196,14 @@ defaults:
       # DO NOT modify the following parameter unless you are confident enough
       # to update the code of all other post links in this project.
       permalink: /posts/:title/
+  - scope:
+      path: ""
+      type: projects
+    values:
+      layout: post
+      toc: true
+      comments: false
+      permalink: /projects/:title/
   - scope:
       path: _drafts
     values:

--- a/_includes/project-feed.html
+++ b/_includes/project-feed.html
@@ -1,0 +1,52 @@
+<div id="project-list" class="flex-grow-1 px-xl-1">
+  {% for project in site.projects %}
+  <article class="card-wrapper card">
+    <a
+      href="{{ project.url | relative_url }}"
+      class="post-preview row g-0 flex-md-row-reverse"
+    >
+      {% assign card_body_col = '12' %} {% if project.image %} {% assign src =
+      project.image.path | default: project.image %} {% unless src contains '//'
+      %} {% assign src = project.media_subpath | append: '/' | append: src |
+      replace: '//', '/' %} {% endunless %} {% assign alt = project.image.alt |
+      xml_escape | default: 'Project Image' %} {% assign lqip = null %} {% if
+      project.image.lqip %} {% capture lqip %}lqip="{{ project.image.lqip }}"{%
+      endcapture %} {% endif %}
+
+      <div class="col-md-5">
+        <img src="{{ src }}" alt="{{ alt }}" {{ lqip }} />
+      </div>
+
+      {% assign card_body_col = '7' %} {% endif %}
+
+      <div class="col-md-{{ card_body_col }}">
+        <div class="card-body d-flex flex-column">
+          <h1 class="card-title my-2 mt-md-0">{{ project.title }}</h1>
+
+          <div class="card-text content mt-0 mb-3">
+            <p>{% include post-description.html post=project %}</p>
+          </div>
+
+          <div class="post-meta flex-grow-1 d-flex align-items-end">
+            <div class="me-auto">
+              <!-- posted date -->
+              <i class="far fa-calendar fa-fw me-1"></i>
+              {% include datetime.html date=project.date lang=site.lang %}
+
+              <!-- categories -->
+              {% if project.categories.size > 0 %}
+              <i class="far fa-folder-open fa-fw me-1"></i>
+              <span class="categories">
+                {% for category in project.categories %} {{ category }} {%-
+                unless forloop.last -%},{%- endunless -%} {% endfor %}
+              </span>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+    </a>
+  </article>
+  {% endfor %}
+</div>
+<!-- #project-list -->

--- a/_projects/market-analysis-dashboard.md
+++ b/_projects/market-analysis-dashboard.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: "Market Analysis Dashboard"
+date: 2022-12-01
+excerpt: |
+  An interactive dashboard built in Python and Dash to explore equity market trends and fundamentals.
+tags: [Data Visualization, Python]
+categories: [Finance]
+---
+
+The project integrates financial APIs with a responsive web app for real-time market insights.

--- a/_projects/options-backtester.md
+++ b/_projects/options-backtester.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: "Options Strategy Backtester"
+date: 2023-03-15
+excerpt: |
+  A Python toolkit for evaluating options trading strategies using historical data and Monte Carlo simulation.
+tags: [Quantitative Finance, Backtesting]
+categories: [Finance]
+---
+
+Built with pandas and Plotly, this tool helps analyze risk-adjusted performance across market conditions.

--- a/_tabs/portfolio.md
+++ b/_tabs/portfolio.md
@@ -1,7 +1,0 @@
----
-title: Portfolio
-icon: fas fa-chart-line
-order: 1
----
-
-Explore selected projects in data science, analytics, and quantitative finance. Each entry highlights real-world impact through modeling, visualization, or decision support tools.

--- a/_tabs/projects.md
+++ b/_tabs/projects.md
@@ -1,0 +1,9 @@
+---
+title: Projects
+icon: fas fa-chart-line
+order: 1
+---
+
+Browse selected projects in data science, analytics, and quantitative finance. Each entry highlights real-world impact through modeling, visualization, or decision support tools.
+
+{% include project-feed.html %}


### PR DESCRIPTION
## Summary
- configure a `projects` collection in `_config.yml`
- add project documents under `_projects`
- create include `project-feed.html` for listing projects
- update portfolio tab to display project list

## Testing
- `bundle install`
- `bundle exec jekyll build`

Closes #17

------
https://chatgpt.com/codex/tasks/task_e_686d7c5fe7148330b0b4a2585144a9a5