### PR TITLE
Use excerpt attribute for post descriptions

### DIFF
--- a/_includes/post-description.html
+++ b/_includes/post-description.html
@@ -1,11 +1,13 @@
 {%- comment -%}
-  Get post description or generate it from the post content.
+  Get post excerpt/description or generate it from the post content.
 {%- endcomment -%}
 
 {%- assign max_length = include.max_length | default: 200 -%}
 
 {%- capture description -%}
-{%- if post.description -%}
+{%- if post.excerpt -%}
+  {{- post.excerpt | markdownify | strip_html -}}
+{%- elsif post.description -%}
   {{- post.description -}}
 {%- else -%}
   {%- include no-linenos.html content=post.content -%}

--- a/_includes/project-feed.html
+++ b/_includes/project-feed.html
@@ -24,7 +24,8 @@
           <h1 class="card-title my-2 mt-md-0">{{ project.title }}</h1>
 
           <div class="card-text content mt-0 mb-3">
-            <p>{% include post-description.html post=project %}</p>
+            {% assign post = project %}
+            <p>{% include post-description.html %}</p>
           </div>
 
           <div class="post-meta flex-grow-1 d-flex align-items-end">


### PR DESCRIPTION
## Summary
- support using `excerpt` front matter in posts

## Testing
- `bash tools/test.sh` *(fails: internally linking to categories/tags that do not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686dcc9d2824833085a0023e96f6f8a1