### PR TITLE
Enable multi-collection archive pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :jekyll_plugins do
   gem "jekyll-feed"
   gem "jekyll-compose"
   gem "jekyll-last-modified-at"
+  gem "jekyll-archives-v2"
 end
 
 gem "html-proofer", "~> 5.0", group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     jekyll-theme-chirpy (7.2.4)
       jekyll (~> 4.3)
-      jekyll-archives (~> 2.2)
+      jekyll-archives-v2 (~> 0.0.6)
       jekyll-include-cache (~> 0.2)
       jekyll-paginate (~> 1.1)
       jekyll-redirect-from (~> 0.16)
@@ -14,6 +14,19 @@ GEM
   remote: https://rubygems.org/
   specs:
     Ascii85 (2.0.1)
+    activesupport (8.0.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     afm (0.2.2)
@@ -24,14 +37,17 @@ GEM
       metrics (~> 0.12)
       traces (~> 0.15)
     base64 (0.3.0)
+    benchmark (0.4.1)
     bigdecimal (3.2.2)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
     console (1.30.2)
       fiber-annotation
       fiber-local (~> 1.1)
       json
     csv (3.3.5)
+    drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -105,7 +121,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-archives (2.3.0)
+    jekyll-archives-v2 (0.0.6)
+      activesupport
       jekyll (>= 3.6, < 5.0)
     jekyll-compose (0.12.0)
       jekyll (>= 3.7, < 5.0)
@@ -135,8 +152,10 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
     metrics (0.12.2)
+    minitest (5.25.5)
     nokogiri (1.18.8-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.8-aarch64-linux-musl)
@@ -188,6 +207,7 @@ GEM
       google-protobuf (~> 4.31)
     sass-embedded (1.89.1-x86_64-linux-musl)
       google-protobuf (~> 4.31)
+    securerandom (0.4.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     traces (0.15.2)
@@ -195,7 +215,10 @@ GEM
       bigdecimal (~> 3.1)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
+    uri (1.0.3)
     webrick (1.9.1)
     yell (2.2.2)
     zeitwerk (2.7.3)
@@ -214,6 +237,7 @@ PLATFORMS
 
 DEPENDENCIES
   html-proofer (~> 5.0)
+  jekyll-archives-v2
   jekyll-compose
   jekyll-feed
   jekyll-last-modified-at

--- a/_config.yml
+++ b/_config.yml
@@ -159,6 +159,7 @@ plugins:
   - jekyll-seo-tag
   - jekyll-last-modified-at
   - jekyll-compose
+  - jekyll-archives-v2
 
 # ------------ The following options are not recommended to be modified ------------------
 
@@ -243,13 +244,22 @@ exclude:
   - "package*.json"
 
 jekyll-archives:
-  enabled: [categories, tags]
-  layouts:
-    category: category
-    tag: tag
-  permalinks:
-    tag: /tags/:name/
-    category: /categories/:name/
+  posts:
+    enabled: [categories, tags]
+    layouts:
+      categories: category
+      tags: tag
+    permalinks:
+      tags: /tags/:name/
+      categories: /categories/:name/
+  projects:
+    enabled: [categories, tags]
+    layouts:
+      categories: category
+      tags: tag
+    permalinks:
+      tags: /tags/:name/
+      categories: /categories/:name/
 
 jekyll_compose:
   default_front_matter:

--- a/_layouts/archives.html
+++ b/_layouts/archives.html
@@ -1,6 +1,6 @@
 ---
 layout: page
-# The Archives of posts.
+# The Archives of posts and projects.
 ---
 
 {% include lang.html %}
@@ -9,8 +9,11 @@ layout: page
 {% assign df_dayjs_m = site.data.locales[lang].df.archives.dayjs | default: '/ MM' %}
 
 <div id="archives" class="pl-xl-3">
-  {% for post in site.posts %}
-    {% assign cur_year = post.date | date: '%Y' %}
+{% assign all_docs = site.documents | where_exp: 'd',
+  'd.collection == "posts" or d.collection == "projects"' |
+  sort: 'date' | reverse %}
+{% for doc in all_docs %}
+  {% assign cur_year = doc.date | date: '%Y' %}
 
     {% if cur_year != last_year %}
       {% unless forloop.first %}</ul>{% endunless %}
@@ -22,12 +25,12 @@ layout: page
     {% endif %}
 
     <li>
-      {% assign ts = post.date | date: '%s' %}
-      <span class="date day" data-ts="{{ ts }}" data-df="DD">{{ post.date | date: '%d' }}</span>
+      {% assign ts = doc.date | date: '%s' %}
+      <span class="date day" data-ts="{{ ts }}" data-df="DD">{{ doc.date | date: '%d' }}</span>
       <span class="date month small text-muted ms-1" data-ts="{{ ts }}" data-df="{{ df_dayjs_m }}">
-        {{ post.date | date: df_strftime_m }}
+        {{ doc.date | date: df_strftime_m }}
       </span>
-      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      <a href="{{ doc.url | relative_url }}">{{ doc.title }}</a>
     </li>
 
     {% if forloop.last %}</ul>{% endif %}

--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -10,11 +10,20 @@ layout: page
 
 {% assign group_index = 0 %}
 
-{% assign sort_categories = site.categories | sort %}
+{% assign all_docs = site.documents | where_exp: 'd',
+  'd.collection == "posts" or d.collection == "projects"' %}
+{% assign category_names = '' | split: '' %}
+{% for doc in all_docs %}
+  {% for c in doc.categories %}
+    {% unless category_names contains c %}
+      {% assign category_names = category_names | push: c %}
+    {% endunless %}
+  {% endfor %}
+{% endfor %}
+{% assign sort_categories = category_names | sort %}
 
-{% for category in sort_categories %}
-  {% assign category_name = category | first %}
-  {% assign posts_of_category = category | last %}
+{% for category_name in sort_categories %}
+  {% assign posts_of_category = all_docs | where_exp:'d','d.categories contains category_name' %}
   {% assign first_post = posts_of_category | first %}
 
   {% if category_name == first_post.categories[0] %}
@@ -45,7 +54,7 @@ layout: page
           <a href="{{ _category_url | relative_url }}" class="mx-2">{{ category_name }}</a>
 
           <!-- content count -->
-          {% assign top_posts_size = site.categories[category_name] | size %}
+          {% assign top_posts_size = posts_of_category | size %}
           <span class="text-muted small font-weight-light">
             {% if sub_categories_size > 0 %}
               {{ sub_categories_size }}
@@ -109,7 +118,7 @@ layout: page
                 {% capture _sub_ctg_url %}/categories/{{ sub_category | slugify | url_encode }}/{% endcapture %}
                 <a href="{{ _sub_ctg_url | relative_url }}" class="mx-2">{{ sub_category }}</a>
 
-                {% assign posts_size = site.categories[sub_category] | size %}
+                {% assign posts_size = all_docs | where_exp:'d','d.categories contains sub_category' | size %}
                 <span class="text-muted small font-weight-light">
                   {{ posts_size }}
 

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -9,11 +9,11 @@ layout: page
   <h1 class="ps-lg-2">
     <i class="far fa-folder-open fa-fw text-muted"></i>
     {{ page.title }}
-    <span class="lead text-muted ps-2">{{ page.posts | size }}</span>
+    <span class="lead text-muted ps-2">{{ page.documents | size }}</span>
   </h1>
 
   <ul class="content ps-0">
-    {% for post in page.posts %}
+    {% for post in page.documents %}
       <li class="d-flex justify-content-between px-md-3">
         <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
         <span class="dash flex-grow-1"></span>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -9,10 +9,10 @@ layout: page
   <h1 class="ps-lg-2">
     <i class="fa fa-tag fa-fw text-muted"></i>
     {{ page.title }}
-    <span class="lead text-muted ps-2">{{ page.posts | size }}</span>
+    <span class="lead text-muted ps-2">{{ page.documents | size }}</span>
   </h1>
   <ul class="content ps-0">
-    {% for post in page.posts %}
+    {% for post in page.documents %}
       <li class="d-flex justify-content-between px-md-3">
         <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
         <span class="dash flex-grow-1"></span>

--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -4,18 +4,24 @@ layout: page
 ---
 
 <div id="tags" class="d-flex flex-wrap mx-xl-2">
-  {% assign tags = '' | split: '' %}
-  {% for t in site.tags %}
-    {% assign tags = tags | push: t[0] %}
+  {% assign all_docs = site.documents | where_exp: 'd',
+    'd.collection == "posts" or d.collection == "projects"' %}
+  {% assign tag_names = '' | split: '' %}
+  {% for doc in all_docs %}
+    {% for tag in doc.tags %}
+      {% unless tag_names contains tag %}
+        {% assign tag_names = tag_names | push: tag %}
+      {% endunless %}
+    {% endfor %}
   {% endfor %}
 
-  {% assign sorted_tags = tags | sort_natural %}
+  {% assign sorted_tags = tag_names | sort_natural %}
 
   {% for t in sorted_tags %}
     <div>
       <a class="tag" href="{{ t | slugify | url_encode | prepend: '/tags/' | append: '/' | relative_url }}">
         {{ t -}}
-        <span class="text-muted">{{ site.tags[t].size }}</span>
+        <span class="text-muted">{{ all_docs | where_exp:'d','d.tags contains t' | size }}</span>
       </a>
     </div>
   {% endfor %}

--- a/jekyll-theme-chirpy.gemspec
+++ b/jekyll-theme-chirpy.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-redirect-from", "~> 0.16"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.8"
-  spec.add_runtime_dependency "jekyll-archives", "~> 2.2"
+  spec.add_runtime_dependency "jekyll-archives-v2", "~> 0.0.6"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.4"
   spec.add_runtime_dependency "jekyll-include-cache", "~> 0.2"
 


### PR DESCRIPTION
## Summary
- install `jekyll-archives-v2`
- configure plugin for `posts` and `projects`
- add plugin to Gemfile and config
- update tag and category layouts to use new `documents` variable

## Testing
- `bundle install`
- `bundle exec jekyll build`

Closes #21

------
https://chatgpt.com/codex/tasks/task_e_686eb33694d8833089a545dbfb2ffceb