### PR TITLE
Fix spacing between date and categories on project cards

### DIFF
--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -114,6 +114,32 @@
       margin-bottom: 1.25rem;
     }
   }
+
+  .post-meta {
+    @extend %muted;
+
+    i {
+      &:not(:first-child) {
+        margin-left: 1.5rem;
+
+        @include bp.md {
+          margin-left: 1.75rem;
+        }
+      }
+    }
+
+    em {
+      @extend %normal-font-style;
+
+      color: inherit;
+    }
+
+    > div:first-child {
+      display: block;
+
+      @extend %text-ellipsis;
+    }
+  }
 }
 
 .pagination {


### PR DESCRIPTION
## Summary
- adjust the project list styles so `.post-meta` uses the same spacing as posts

## Testing
- `npm test`
- `bundle exec jekyll build`
- `bundle exec htmlproofer ./_site --disable-external`


------
https://chatgpt.com/codex/tasks/task_e_686f09c52c688330ab095feaa381fcc9