### PR TITLE
Isolate html-proofer to resolve nokogiri security alert

### DIFF
--- a/.github/workflows/htmlproofer.yml
+++ b/.github/workflows/htmlproofer.yml
@@ -24,10 +24,14 @@ jobs:
         run: bundle install
 
       - name: Build Jekyll site
+        env:
+          SITE_DIR: ${{ github.workspace }}/_site
         run: |
           bundle install
           bundle exec jekyll build
 
       - name: Run html-proofer
         working-directory: ci/htmlproofer
-        run: bundle exec htmlproofer ../../_site
+        env:
+          SITE_DIR: ${{ github.workspace }}/_site
+        run: bundle exec htmlproofer "$SITE_DIR"

--- a/.github/workflows/htmlproofer.yml
+++ b/.github/workflows/htmlproofer.yml
@@ -1,44 +1,33 @@
-name: HTMLProofer Check
+name: HTMLProofer
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-  htmlproofer:
+  link-check:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-      - name: Setup Ruby
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.3
-          bundler-cache: true
+          ruby-version: "3.2.3"
 
-      - name: Install dependencies
-        run: |
-          gem install bundler
-          bundle install
+      - name: Install html-proofer dependencies
+        working-directory: ci/htmlproofer
+        run: bundle install
 
       - name: Build Jekyll site
-        run: bundle exec jekyll build
-
-      - name: List built files (debugging)
         run: |
-          echo "Built site structure:"
-          find ./_site -type f -name "*.html" | head -10
-          echo "Total HTML files: $(find ./_site -type f -name "*.html" | wc -l)"
+          bundle install
+          bundle exec jekyll build
 
-      - name: Run HTMLProofer (Internal Links Only - Temporary)
-        run: |
-          echo "Running HTMLProofer with internal links only (temporary fix):"
-          bundle exec htmlproofer ./_site --disable-external
-
-      - name: Run HTMLProofer (Full Check - Commented Out)
-        if: false # Disabled until we fix external link issues
-        run: |
-          echo "Running HTMLProofer with config:"
-          cat .htmlproofer.yml
-          echo "Checking for problematic Google Fonts links:"
-          grep -r "fonts\.googleapis\.com\|fonts\.gstatic\.com" ./_site/ | head -5 || echo "No Google Fonts links found"
-          bundle exec htmlproofer ./_site
+      - name: Run html-proofer
+        working-directory: ci/htmlproofer
+        run: bundle exec htmlproofer ../../_site

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :jekyll_plugins do
   gem "jekyll-archives-v2"
 end
 
-# Waiting for updated version that is based on nokogiri >= 1.18.9
+# Waiting for html-proofer to support nokogiri >= 1.18.9 (see https://github.com/gjtorikian/html-proofer/issues/708)
 # gem "html-proofer", "~> 5.0", group: :test
 
 platforms :mingw, :x64_mingw, :mswin, :jruby do

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'nokogiri', '>= 1.18.9'
+
 group :jekyll_plugins do
   gem "jekyll-feed"
   gem "jekyll-compose"
@@ -11,7 +13,8 @@ group :jekyll_plugins do
   gem "jekyll-archives-v2"
 end
 
-gem "html-proofer", "~> 5.0", group: :test
+# Waiting for updated version that is based on nokogiri >= 1.18.9
+# gem "html-proofer", "~> 5.0", group: :test
 
 platforms :mingw, :x64_mingw, :mswin, :jruby do
   gem "tzinfo", ">= 1", "< 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    Ascii85 (2.0.1)
-    activesupport (8.0.2)
+    activesupport (8.0.2.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -29,79 +28,60 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    afm (0.2.2)
-    async (2.24.0)
-      console (~> 1.29)
-      fiber-annotation
-      io-event (~> 1.9)
-      metrics (~> 0.12)
-      traces (~> 0.15)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.3)
-    console (1.30.2)
-      fiber-annotation
-      fiber-local (~> 1.1)
-      json
+    connection_pool (2.5.4)
     csv (3.3.5)
     drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.16.0)
-      ffi (>= 1.15.0)
     eventmachine (1.2.7)
+    ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
     ffi (1.17.2-arm-linux-musl)
     ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
-    fiber-annotation (0.2.0)
-    fiber-local (1.1.0)
-      fiber-storage
-    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
-    google-protobuf (4.31.1)
+    google-protobuf (4.32.1)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-aarch64-linux-gnu)
+    google-protobuf (4.32.1-aarch64-linux-gnu)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-aarch64-linux-musl)
+    google-protobuf (4.32.1-aarch64-linux-musl)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-arm64-darwin)
+    google-protobuf (4.32.1-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-x86_64-darwin)
+    google-protobuf (4.32.1-x86-linux-gnu)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-x86_64-linux-gnu)
+    google-protobuf (4.32.1-x86-linux-musl)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-x86_64-linux-musl)
+    google-protobuf (4.32.1-x86_64-darwin)
       bigdecimal
       rake (>= 13)
-    hashery (2.1.2)
-    html-proofer (5.0.10)
-      addressable (~> 2.3)
-      async (~> 2.1)
-      nokogiri (~> 1.13)
-      pdf-reader (~> 2.11)
-      rainbow (~> 3.0)
-      typhoeus (~> 1.3)
-      yell (~> 2.0)
-      zeitwerk (~> 2.5)
+    google-protobuf (4.32.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
     http_parser.rb (0.8.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    io-event (1.10.1)
     jekyll (4.4.1)
       addressable (~> 2.4)
       base64 (~> 0.2)
@@ -143,7 +123,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.12.2)
+    json (2.13.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -154,97 +134,109 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.4.0)
-    metrics (0.12.2)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
-    nokogiri (1.18.8-aarch64-linux-gnu)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.8-aarch64-linux-musl)
+    nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.8-arm-linux-gnu)
+    nokogiri (1.18.10-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.8-arm-linux-musl)
+    nokogiri (1.18.10-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.8-arm64-darwin)
+    nokogiri (1.18.10-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-darwin)
+    nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-musl)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    pdf-reader (2.14.1)
-      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
-      afm (~> 0.2.1)
-      hashery (~> 2.0)
-      ruby-rc4
-      ttfunk
     public_suffix (6.0.2)
     racc (1.8.1)
-    rainbow (3.1.1)
     rake (13.3.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.4.1)
-    rouge (4.5.2)
-    ruby-rc4 (0.1.5)
+    rexml (3.4.4)
+    rouge (4.6.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.89.1-aarch64-linux-gnu)
+    sass-embedded (1.92.1)
       google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-aarch64-linux-musl)
+      rake (>= 13)
+    sass-embedded (1.92.1-aarch64-linux-android)
       google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-arm-linux-gnueabihf)
+    sass-embedded (1.92.1-aarch64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-arm-linux-musleabihf)
+    sass-embedded (1.92.1-aarch64-linux-musl)
       google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-arm64-darwin)
+    sass-embedded (1.92.1-arm-linux-androideabi)
       google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-x86_64-darwin)
+    sass-embedded (1.92.1-arm-linux-gnueabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-x86_64-linux-gnu)
+    sass-embedded (1.92.1-arm-linux-musleabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-x86_64-linux-musl)
+    sass-embedded (1.92.1-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.92.1-x86_64-linux-musl)
       google-protobuf (~> 4.31)
     securerandom (0.4.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    traces (0.15.2)
-    ttfunk (1.8.0)
-      bigdecimal (~> 3.1)
-    typhoeus (1.4.1)
-      ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     uri (1.0.3)
     webrick (1.9.1)
-    yell (2.2.2)
-    zeitwerk (2.7.3)
 
 PLATFORMS
+  aarch64-linux-android
   aarch64-linux-gnu
   aarch64-linux-musl
+  arm-linux-androideabi
   arm-linux-gnu
   arm-linux-gnueabihf
   arm-linux-musl
   arm-linux-musleabihf
   arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
   x86_64-darwin
+  x86_64-linux-android
   x86_64-linux-gnu
   x86_64-linux-musl
 
 DEPENDENCIES
-  html-proofer (~> 5.0)
   jekyll-archives-v2
   jekyll-compose
   jekyll-feed
   jekyll-last-modified-at
   jekyll-theme-chirpy!
+  nokogiri (>= 1.18.9)
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.2.0)
 
 BUNDLED WITH
-   2.6.9
+   2.7.2

--- a/ci/htmlproofer/Gemfile
+++ b/ci/htmlproofer/Gemfile
@@ -1,0 +1,4 @@
+# ci/htmlproofer/Gemfile
+source 'https://rubygems.org'
+
+gem 'html-proofer', '5.0.10'

--- a/ci/htmlproofer/Gemfile.lock
+++ b/ci/htmlproofer/Gemfile.lock
@@ -1,0 +1,94 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    Ascii85 (2.0.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    afm (1.0.0)
+    async (2.32.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
+    bigdecimal (3.2.3)
+    console (1.34.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
+    hashery (2.1.2)
+    html-proofer (5.0.10)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
+    io-event (1.11.2)
+    json (2.13.2)
+    metrics (0.15.0)
+    nokogiri (1.18.10-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
+      racc (~> 1.4)
+    pdf-reader (2.15.0)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
+    public_suffix (6.0.2)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    ruby-rc4 (0.1.5)
+    traces (0.18.2)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
+    typhoeus (1.5.0)
+      ethon (>= 0.9.0, < 0.16.0)
+    yell (2.2.2)
+    zeitwerk (2.7.3)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  html-proofer (= 5.0.10)
+
+BUNDLED WITH
+   2.7.2


### PR DESCRIPTION
## ✅ Description:

This PR resolves a security alert related to nokogiri < 1.18.9 by removing html-proofer from the main Gemfile and isolating it in a dedicated test environment.

## 🔧 Changes

- **Removed:** html-proofer from the main Gemfile to allow unlocking nokogiri
- **Added:** nokogiri >= 1.18.9 as a top-level dependency
- **Created:** ci/htmlproofer/Gemfile for running link checks independently
- **Updated:** htmlproofer.yml workflow to use the isolated environment

✅ Benefits

- Unlocks and upgrades nokogiri, resolving the Dependabot security alert
- Preserves link-checking in local and CI workflows
- Clean separation between runtime and test-only dependencies