### PR TITLE
fix(ci): ignore bot-protected W3Schools links in HTMLProofer workflow

### DIFF
--- a/.github/workflows/htmlproofer.yml
+++ b/.github/workflows/htmlproofer.yml
@@ -34,4 +34,6 @@ jobs:
         working-directory: ci/htmlproofer
         env:
           SITE_DIR: ${{ github.workspace }}/_site
-        run: bundle exec htmlproofer "$SITE_DIR" --ignore-urls "/fonts.googleapis.com/,/fonts.gstatic.com/,/linkedin.com/,/tutorials.jenkov.com/,/reddit.com/"
+        # W3Schools rejects requests from GitHub-hosted runners with HTTP 403,
+        # even when the linked page is available in a browser.
+        run: bundle exec htmlproofer "$SITE_DIR" --ignore-urls "/fonts.googleapis.com/,/fonts.gstatic.com/,/linkedin.com/,/tutorials.jenkov.com/,/reddit.com/,/w3schools.com/"


### PR DESCRIPTION
### Motivation
- Prevent spurious HTMLProofer CI failures caused by external sites (W3Schools) returning HTTP 403 to GitHub-hosted runners while pages are valid in a browser.

### Description
- Update `.github/workflows/htmlproofer.yml` to add `'/w3schools.com/'` to the `--ignore-urls` list and include a short comment explaining the narrow exception.

### Testing
- Ran `git diff --check` which passed.
- Parsed the workflow with Ruby using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/htmlproofer.yml', aliases: true)"` which reported the YAML as valid.
- Built the site with `bundle exec jekyll build` which completed successfully.
- Verified the targeted exclusion with a fixture using `(cd ci/htmlproofer && bundle exec htmlproofer <fixture> --ignore-urls "/w3schools.com/")`, which finished successfully and demonstrated W3Schools links are ignored.
- Ran a full `htmlproofer` pass against `_site` which could not complete in this environment because the runner/proxy rejected many unrelated external hosts (status code `0`), but the scoped `w3schools.com` exclusion behaves as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77b24a1cd48330a2dd446abc4c2a60)