### PR TITLE
Add smoke tests and CI job for blog header generator

### DIFF
--- a/.github/workflows/header-generator.yml
+++ b/.github/workflows/header-generator.yml
@@ -1,0 +1,39 @@
+name: Header Generator
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "tools/generate_blog_header.py"
+      - "tests/test_generate_blog_header.py"
+      - "assets/lib/fonts/Source_Sans_Pro/**"
+      - "requirements.txt"
+      - ".github/workflows/header-generator.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "tools/generate_blog_header.py"
+      - "tests/test_generate_blog_header.py"
+      - "assets/lib/fonts/Source_Sans_Pro/**"
+      - "requirements.txt"
+      - ".github/workflows/header-generator.yml"
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install pinned Python dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run header generator smoke tests
+        run: python -m unittest tests/test_generate_blog_header.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ package-lock.json
 
 # Python environment
 venv
+__pycache__/
 
 # Misc

--- a/README.md
+++ b/README.md
@@ -59,11 +59,17 @@ Blog posts can include standardized header images generated automatically. Use
 colors:
 
 ```bash
-python3 tools/generate_header.py "Post Title" --subtitle "Optional subtitle" -o \
+python3 tools/generate_blog_header.py "Post Title" --subtitle "Optional subtitle" -o \
   assets/img/headers/post-title.png
 ```
 
 The script requires the `Pillow` package (see `requirements.txt`).
+Install the pinned dependencies and run its smoke test locally with:
+
+```sh
+python3 -m pip install -r requirements.txt
+python3 -m unittest tests/test_generate_blog_header.py -v
+```
 
 ## 🧪 Development Notes
 

--- a/tests/test_generate_blog_header.py
+++ b/tests/test_generate_blog_header.py
@@ -1,0 +1,125 @@
+"""Command-line smoke tests for the blog header generator."""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+GENERATOR = REPOSITORY_ROOT / 'tools' / 'generate_blog_header.py'
+
+
+class GenerateBlogHeaderSmokeTest(unittest.TestCase):
+    def run_generator(self, *arguments):
+        """Run the generator as a user would from the repository root."""
+        return subprocess.run(
+            [sys.executable, str(GENERATOR), *map(str, arguments)],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def assert_valid_header(self, output_path):
+        """Check stable PNG properties rather than renderer-specific pixels."""
+        self.assertTrue(output_path.is_file())
+        with Image.open(output_path) as image:
+            image.verify()
+        with Image.open(output_path) as image:
+            self.assertEqual(image.format, 'PNG')
+            self.assertEqual(image.size, (1200, 630))
+            self.assertEqual(image.mode, 'RGB')
+            self.assertIsNotNone(image.getbbox())
+
+    def test_title_only_creates_missing_output_directory(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / 'missing' / 'header.png'
+
+            result = self.run_generator(
+                'A representative blog title', '-o', output
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assert_valid_header(output)
+
+    def test_title_with_subtitle_creates_valid_header(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / 'header-with-subtitle.png'
+
+            result = self.run_generator(
+                'A representative blog title',
+                '--subtitle',
+                'A useful explanatory subtitle',
+                '--output',
+                output,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assert_valid_header(output)
+
+    def test_missing_fonts_fail_with_clear_message(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            temporary_generator = temporary_root / 'tools' / GENERATOR.name
+            temporary_generator.parent.mkdir()
+            shutil.copy2(GENERATOR, temporary_generator)
+            output = temporary_root / 'header.png'
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(temporary_generator),
+                    'Title',
+                    '-o',
+                    str(output),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('Required font asset is missing:', result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_incompatible_fonts_fail_with_clear_message(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            temporary_generator = temporary_root / 'tools' / GENERATOR.name
+            temporary_generator.parent.mkdir()
+            shutil.copy2(GENERATOR, temporary_generator)
+            font_directory = (
+                temporary_root / 'assets' / 'lib' / 'fonts' / 'Source_Sans_Pro'
+            )
+            font_directory.mkdir(parents=True)
+            for font_name in ('SourceSansPro-Bold.ttf',
+                              'SourceSansPro-Regular.ttf'):
+                (font_directory / font_name).write_text('not a font')
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(temporary_generator),
+                    'Title',
+                    '-o',
+                    str(temporary_root / 'header.png'),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                'Required font asset is incompatible or unreadable:',
+                result.stderr,
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/generate_blog_header.py
+++ b/tools/generate_blog_header.py
@@ -28,6 +28,19 @@ TITLE_FONT_SIZE = 80
 SUBTITLE_FONT_SIZE = 48
 
 
+def load_font(path, size):
+    """Load a required bundled font with an actionable error message."""
+    if not path.is_file():
+        raise RuntimeError(f'Required font asset is missing: {path}')
+
+    try:
+        return ImageFont.truetype(str(path), size)
+    except OSError as error:
+        raise RuntimeError(
+            f'Required font asset is incompatible or unreadable: {path}'
+        ) from error
+
+
 def draw_centered_text(draw, text, font, y):
     """
     Wrap and center-align text within the image boundaries.
@@ -89,9 +102,12 @@ if __name__ == '__main__':
     draw = ImageDraw.Draw(img)
 
     # Load fonts
-    title_font = ImageFont.truetype(str(FONT_BOLD), TITLE_FONT_SIZE)
-    global SUBTITLE_FONT
-    SUBTITLE_FONT = ImageFont.truetype(str(FONT_REGULAR), SUBTITLE_FONT_SIZE)
+    try:
+        title_font = load_font(FONT_BOLD, TITLE_FONT_SIZE)
+        global SUBTITLE_FONT
+        SUBTITLE_FONT = load_font(FONT_REGULAR, SUBTITLE_FONT_SIZE)
+    except RuntimeError as error:
+        parser.error(str(error))
 
     # Render text
     y = HEIGHT // 3 - TITLE_FONT_SIZE


### PR DESCRIPTION
### Motivation

- Ensure `tools/generate_blog_header.py` is exercised by an automated smoke test so Pillow or font changes cannot be merged without detection.
- Verify the script's CLI, automatic output-directory creation, and generated PNG structure and dimensions (`1200×630`) using the repository's bundled fonts.
- Fail clearly when bundled fonts are missing or unreadable to surface asset incompatibilities early in CI.

### Description

- Add CLI-level smoke tests at `tests/test_generate_blog_header.py` covering title-only and title-with-subtitle invocations, automatic output-directory creation, PNG validity, exact dimensions, RGB mode, and missing/incompatible font failure messages.
- Harden font loading in `tools/generate_blog_header.py` by adding `load_font()` with actionable `RuntimeError` messages and surfacing them via `parser.error()` for clear CLI errors.
- Add a focused GitHub Actions workflow at `.github/workflows/header-generator.yml` that installs pinned Python dependencies from `requirements.txt` and runs the smoke tests on relevant file changes.
- Update `README.md` to correct the generator command and document how to install dependencies and run the smoke tests locally with `python3 -m pip install -r requirements.txt` and `python3 -m unittest tests/test_generate_blog_header.py -v`.

### Testing

- Ran the smoke tests with `python3 -m unittest tests/test_generate_blog_header.py -v`, and all tests passed (`4 tests, OK`).
- Ran style and static checks with `python3 -m flake8 tools/generate_blog_header.py tests/test_generate_blog_header.py` and `python3 -m py_compile tools/generate_blog_header.py tests/test_generate_blog_header.py`, both succeeded.
- Validated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/header-generator.yml')"` and `npx markdownlint-cli2 README.md`, both succeeded.
- Ran repository checks `git diff --check`, which reported no issues; an unrelated pre-existing `npm test` stylelint warning remains in `_sass/pages/_post.scss` and was not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77bd95f31883308a70a218123069a8)