### PR TITLE
ci: separate external link validation

### DIFF
--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -1,0 +1,31 @@
+name: External Links
+
+on:
+  schedule:
+    - cron: "17 8 * * 1"
+  workflow_dispatch:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2.3"
+          bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build Jekyll site
+        run: bundle exec jekyll build
+
+      - name: Check external links
+        run: tools/check_external_links.sh _site

--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -4,9 +4,16 @@ on:
   schedule:
     - cron: "17 8 * * 1"
   workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/external-links.yml"
+      - "linkinator.config.json"
+      - "tools/check_external_links.sh"
 
 jobs:
   link-check:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -29,3 +36,38 @@ jobs:
 
       - name: Check external links
         run: tools/check_external_links.sh _site
+
+  smoke-test:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Create smoke-test site
+        run: |
+          mkdir _site-smoke
+          printf '<a href="assets/missing-file.png">Internal link</a>\n' > _site-smoke/index.html
+
+      - name: Validate URL skip scope
+        run: |
+          node - <<'NODE'
+          const { skip } = require('./linkinator.config.json');
+          const isSkipped = (url) => skip.some((pattern) => new RegExp(pattern).test(url));
+
+          if (!isSkipped('http://127.0.0.1:12345/assets/missing-file.png')) {
+            throw new Error('A locally resolved site URL was not skipped');
+          }
+          if (isSkipped('https://example.com/blog/article')) {
+            throw new Error('A third-party URL was incorrectly skipped');
+          }
+          NODE
+
+      - name: Run Linkinator smoke test
+        run: tools/check_external_links.sh _site-smoke

--- a/.github/workflows/htmlproofer.yml
+++ b/.github/workflows/htmlproofer.yml
@@ -34,6 +34,5 @@ jobs:
         working-directory: ci/htmlproofer
         env:
           SITE_DIR: ${{ github.workspace }}/_site
-        # W3Schools rejects requests from GitHub-hosted runners with HTTP 403,
-        # even when the linked page is available in a browser.
-        run: bundle exec htmlproofer "$SITE_DIR" --ignore-urls "/fonts.googleapis.com/,/fonts.gstatic.com/,/linkedin.com/,/tutorials.jenkov.com/,/reddit.com/,/w3schools.com/"
+        # External availability is intentionally handled by external-links.yml.
+        run: bundle exec htmlproofer "$SITE_DIR" --disable-external --no-enforce-https

--- a/README.md
+++ b/README.md
@@ -34,9 +34,45 @@ The build and deployment workflow:
 2. Push changes to the `main` branch on GitHub.
 3. Cloudflare Pages automatically builds and deploys the site from GitHub.
 
-A GitHub Actions workflow ([`htmlproofer.yml`](.github/workflows/htmlproofer.yml))
-validates the generated HTML, while deployment is handled directly by Cloudflare
-Pages.
+The blocking GitHub Actions workflow
+([`htmlproofer.yml`](.github/workflows/htmlproofer.yml)) validates generated HTML,
+internal links and anchors, images, and scripts. It deliberately does not make
+requests to third-party sites. The scheduled and manually triggered
+[`external-links.yml`](.github/workflows/external-links.yml) workflow reports
+external-link health separately, so transient outages and bot protection do not
+block unrelated pull requests. Deployment is handled directly by Cloudflare Pages.
+
+### Link validation
+
+Build the site before running either validation path:
+
+```sh
+bundle install
+bundle exec jekyll build
+```
+
+Run the deterministic internal-site checks with HTMLProofer:
+
+```sh
+bundle install --gemfile ci/htmlproofer/Gemfile
+BUNDLE_GEMFILE=ci/htmlproofer/Gemfile bundle exec htmlproofer _site \
+  --disable-external --no-enforce-https
+```
+
+Run the external-link report with the pinned Linkinator version used in CI:
+
+```sh
+tools/check_external_links.sh _site
+```
+
+The helper invokes the pinned Linkinator version and flattens the generated pages
+into temporary entry points. A name such as `posts__example__index.html` in the
+report maps to `_site/posts/example/index.html`. Linkinator's repository-level
+configuration retries transient failures and treats HTTP 403 and 999
+bot-protection responses as warnings. Its informational output includes the source
+page and checked URL. Add URL exclusions to
+`linkinator.config.json` only when a narrowly identified endpoint cannot be checked
+reliably.
 
 ## 📁 Repository Structure
 

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,0 +1,28 @@
+{
+  "recurse": false,
+  "verbosity": "info",
+  "timeout": 20000,
+  "retry": true,
+  "retryErrors": true,
+  "retryErrorsCount": 2,
+  "retryErrorsJitter": 2,
+  "skip": [
+    "jeremiahharemza.com/",
+    "assets/",
+    "about/",
+    "archives/",
+    "blog/",
+    "categories/",
+    "contact/",
+    "norobots/",
+    "posts/",
+    "projects/",
+    "resume/",
+    "tags/",
+    "feed.xml"
+  ],
+  "statusCodes": {
+    "403": "warn",
+    "999": "warn"
+  }
+}

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -7,19 +7,8 @@
   "retryErrorsCount": 2,
   "retryErrorsJitter": 2,
   "skip": [
-    "jeremiahharemza.com/",
-    "assets/",
-    "about/",
-    "archives/",
-    "blog/",
-    "categories/",
-    "contact/",
-    "norobots/",
-    "posts/",
-    "projects/",
-    "resume/",
-    "tags/",
-    "feed.xml"
+    "^http://127\\.0\\.0\\.1:[0-9]+/(?:$|(?:assets|about|archives|blog|categories|contact|norobots|posts|projects|resume|tags)(?:/|$)|feed\\.xml$)",
+    "^https?://(?:www\\.)?jeremiahharemza\\.com(?:/|$)"
   ],
   "statusCodes": {
     "403": "warn",

--- a/tools/check_external_links.sh
+++ b/tools/check_external_links.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+site_dir="${1:-_site}"
+input_dir="$(mktemp -d)"
+config_file="$(pwd)/linkinator.config.json"
+trap 'rm -rf "$input_dir"' EXIT
+
+# Flatten the generated pages into distinct entry points. This lets Linkinator
+# report the originating page while the configured path prefixes skip internal
+# links without also excluding pages nested under those prefixes.
+while IFS= read -r -d '' page; do
+  relative_path="${page#"$site_dir"/}"
+  flattened_path="${relative_path//\//__}"
+  cp "$page" "$input_dir/$flattened_path"
+done < <(find "$site_dir" -type f -name '*.html' -print0)
+
+(
+  cd "$input_dir"
+  npx --yes linkinator@8.0.3 "*.html" --config "$config_file"
+)


### PR DESCRIPTION
### Motivation

- Prevent transient external-site failures and bot-protected responses from blocking pull requests by moving external link checks out of the blocking HTMLProofer job. 
- Use Linkinator for comprehensive external-link health reporting with retries and status-code policies while keeping HTMLProofer as the deterministic internal-site validator.

### Description

- Limit the blocking internal validator by running `htmlproofer` with `--disable-external --no-enforce-https` in `.github/workflows/htmlproofer.yml` so it checks only internal links, anchors, images, and scripts.  
- Add a scheduled and manually-dispatchable workflow `.github/workflows/external-links.yml` that builds the Jekyll site and runs external-link checks using Node.js and Linkinator.  
- Add `linkinator.config.json` with timeouts, retry policies, skip prefixes, and `403`/`999` mapped to `warn` so bot-protection responses are reported as warnings.  
- Add `tools/check_external_links.sh` which flattens `_site` HTML pages into temporary entry points and invokes the pinned `linkinator@8.0.3` with the repository config, and update `README.md` with local commands and guidance for both validation paths.

### Testing

- Validated workflow YAMLs with `ruby -e

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77c57dc7248330ac2f07bd720db427)